### PR TITLE
Single-element batch fix

### DIFF
--- a/vendi_score/image_utils.py
+++ b/vendi_score/image_utils.py
@@ -106,7 +106,10 @@ def get_embeddings(
             output = model(x)
         if type(output) == list:
             output = output[0]
-        embeddings.append(output.squeeze().cpu().numpy())
+        output_arr = output.squeeze().cpu().numpy()
+        if output_arr.ndim==1:
+            output_arr = output_arr.reshape(1, output_arr.size)
+        embeddings.append(output_arr)
     return np.concatenate(embeddings, 0)
 
 

--- a/vendi_score/text_utils.py
+++ b/vendi_score/text_utils.py
@@ -111,7 +111,10 @@ def get_embeddings(
                 output = output.last_hidden_state[:, 0]
         if type(output) == list:
             output = output[0]
-        embeddings.append(output.squeeze().cpu().numpy())
+        output_arr = output.squeeze().cpu().numpy()
+        if output_arr.ndim==1:
+            output_arr = output_arr.reshape(1, output_arr.size)
+        embeddings.append(output_arr)
     return np.concatenate(embeddings, 0)
 
 


### PR DESCRIPTION
In case a batch only contains single element (potentially the last batch of batches, e.g. when there are 101 entries where the batch size is 10), `np.concatenate(embeddings, 0)` results in dimension error.
Reshaping to (1, batch_size) should be the fix.